### PR TITLE
Fixes `installPackage` check for REQUEST_INSTALL_PACKAGES

### DIFF
--- a/android/Tools.hx
+++ b/android/Tools.hx
@@ -15,14 +15,8 @@ class Tools
 	 */
 	public static function installPackage(path:String):Void
 	{
-		if (!Permissions.getGrantedPermissions().contains(Permissions.REQUEST_INSTALL_PACKAGES))
-		{
+		if (!installPackage_jni(path))
 			Log.warn('You must have the "REQUEST_INSTALL_PACKAGES" granted in order to install a APK file.');
-
-			return;
-		}
-		
-		installPackage_jni(path);
 	}
 
 	/**
@@ -135,7 +129,7 @@ class Tools
 		return isDexMode_jni();
 	}
 
-	@:noCompletion private static var installPackage_jni:Dynamic = JNI.createStaticMethod('org/haxe/extension/Tools', 'installPackage', '(Ljava/lang/String;)V');
+	@:noCompletion private static var installPackage_jni:Dynamic = JNI.createStaticMethod('org/haxe/extension/Tools', 'installPackage', '(Ljava/lang/String;)Z');
 	@:noCompletion private static var enableAppSecure_jni:Dynamic = JNI.createStaticMethod('org/haxe/extension/Tools', 'enableAppSecure', '()V');
 	@:noCompletion private static var disableAppSecure_jni:Dynamic = JNI.createStaticMethod('org/haxe/extension/Tools', 'disableAppSecure', '()V');
 	@:noCompletion private static var launchPackage_jni:Dynamic = JNI.createStaticMethod('org/haxe/extension/Tools', 'launchPackage', '(Ljava/lang/String;I)V');

--- a/android/Tools.hx
+++ b/android/Tools.hx
@@ -16,7 +16,7 @@ class Tools
 	public static function installPackage(path:String):Void
 	{
 		if (!installPackage_jni(path))
-			Log.warn('You must have the "REQUEST_INSTALL_PACKAGES" granted in order to install a APK file.');
+			Log.warn('"REQUEST_INSTALL_PACKAGES" permission and "Install apps from external sources" setting must be granted to this app in order to install a ${haxe.io.Path.extension(path).toUpperCase()} file.');
 	}
 
 	/**

--- a/project/androidtools/src/main/java/org/haxe/extension/Tools.java
+++ b/project/androidtools/src/main/java/org/haxe/extension/Tools.java
@@ -180,15 +180,12 @@ public class Tools extends Extension
 
 	public static boolean installPackage(final String path)
 	{
-		try {
-
+		try
+		{
+			boolean retVal = true;
 			// return false only if the application dosen't have the necessary permissions or an Exception accured
-			// other API versions has this permission true by default so it's not necessarry to check on them
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-			{
-				if (!mainContext.getPackageManager().canRequestPackageInstalls())
-					return false;
-			}
+				retVal = mainContext.getPackageManager().canRequestPackageInstalls()
 
 			File file = new File(path);
 			Uri contentUri;
@@ -198,19 +195,19 @@ public class Tools extends Extension
 			else
 				contentUri = Uri.fromFile(file);
 
-			if (file.exists()) 
+			if (file.exists())
 			{
 				Intent intent = new Intent(Intent.ACTION_VIEW);
 				intent.setDataAndType(contentUri, "application/vnd.android.package-archive");
 				intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 				intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 				mainContext.startActivity(intent);
-			} 
+			}
 			else 
 			{
 				Log.e(LOG_TAG, "Attempted to install a application package from " + file.getPath() + " but the file dosen't exist.");
 			}
-			return true;
+			return retVal;
 		}
 		catch (Exception e)
 		{

--- a/project/androidtools/src/main/java/org/haxe/extension/Tools.java
+++ b/project/androidtools/src/main/java/org/haxe/extension/Tools.java
@@ -185,7 +185,7 @@ public class Tools extends Extension
 			boolean retVal = true;
 			// return false only if the application dosen't have the necessary permissions or an Exception accured
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-				retVal = mainContext.getPackageManager().canRequestPackageInstalls()
+				retVal = mainContext.getPackageManager().canRequestPackageInstalls();
 
 			File file = new File(path);
 			Uri contentUri;


### PR DESCRIPTION
`REQUEST_INSTALL_PACKAGES` cannot be checked at runtime or smth like that for some reason
well now if it's missing java will catch this Exception and android.Tools will trace saying the permission is missing
![image](https://github.com/MAJigsaw77/extension-androidtools/assets/144803230/38e83ba8-5b98-41be-88fe-e16f3432ffcd)
